### PR TITLE
Poster link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,7 +152,7 @@ export const App = () => {
             <Box textAlign="left" marginRight={8} marginLeft={8} marginTop={5} fontSize="xl" color="purple">
               <HStack justify="space-between">
                 <Heading color="darkgreen">{state.site}</Heading>
-                <Link href={`/posters/${state.site}.png`} isExternal>View Poster <ExternalLinkIcon mx="2px"/></Link>
+                <Link href={`../posters/${state.site}.png`} isExternal>View Poster <ExternalLinkIcon mx="2px"/></Link>
               </HStack>
             </Box>
             <VStack>


### PR DESCRIPTION
Change to relative link so it works when build files are copied to whatgoeswhere dir and served with gh pages